### PR TITLE
add support for java track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 workspace/*
+.env

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ LEIN_REPL_PORT=4444 \
   make run_track
 ```
 
+### [Java](https://exercism.io/my/tracks/java)
 ### [Python](https://exercism.io/my/tracks/python)
 ### [Ruby](https://exercism.io/my/tracks/ruby)
 

--- a/tracks/java/Dockerfile
+++ b/tracks/java/Dockerfile
@@ -1,0 +1,16 @@
+FROM exercism:latest
+
+MAINTAINER matt@matthewbilyeu.com
+
+ENV TRACK java
+
+# via https://exercism.io/tracks/java/installation#linux
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install -y \
+    curl \
+    zip \
+    unzip
+RUN curl -s "https://get.sdkman.io" | bash
+RUN chmod a+x "$HOME/.sdkman/bin/sdkman-init.sh"
+RUN bash -c 'source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install java 11.0.2-open && sdk install gradle'

--- a/tracks/java/docker-run.sh
+++ b/tracks/java/docker-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker run -it --rm \
+       -e TOKEN=$TOKEN \
+       -v "$BASE_PATH"/workspace:/workspace \
+       exercism-io--$TRACK:latest


### PR DESCRIPTION
Adds support for [Exercism Java track](https://exercism.io/my/tracks/java), using [these installation instructions](https://exercism.io/tracks/java/installation#linux)

Manually tested by completing "Hello World" exercise:

```
root@ae506244b1cf:/workspace/java/hello-world# gradle test

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
3 actionable tasks: 3 up-to-date
```